### PR TITLE
fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,24 +22,21 @@ Start by adding [JSONView](https://chrome.google.com/webstore/detail/jsonview/ch
 
 Read each section and be ready to answer questions  
 
-1. [Request and response pattern](https://github.com/lucymonie/api-workshop/blob/master/01-request-response.md)  
+1. [Request and response pattern](https://github.com/foundersandcoders/api-workshop/blob/master/01-request-response.md)  
 
-2. [HTTP](https://github.com/lucymonie/api-workshop/blob/master/02-http.md)  
+2. [HTTP](https://github.com/foundersandcoders/api-workshop/blob/master/02-http.md)  
 
-3. [XMLHttpRequests](https://github.com/lucymonie/api-workshop/blob/master/03-xmlhttprequest.md)  
+3. [XMLHttpRequests](https://github.com/foundersandcoders/api-workshop/blob/master/03-xmlhttprequest.md)  
 
-4. [asynchronous code](https://github.com/lucymonie/api-workshop/blob/master/04-asynchonous.md)  
+4. [Asynchronous code](https://github.com/foundersandcoders/api-workshop/blob/master/04-asynchonous.md)  
 
-5. Example one: [fix a broken API request](https://github.com/lucymonie/api-workshop/tree/master/api-example)  
+5. [Fix a broken API request](https://github.com/foundersandcoders/api-workshop/tree/master/api-example)  
     - You will need to clone the repository and work on the code locally
-    - If you have ssh keys for github: `git clone git@github.com:lucymonie/api-workshop.git`
-    - Otherwise, use:`git clone https://github.com/lucymonie/api-workshop.git`
+    - If you have ssh keys for github: `git clone git@github.com:foundersandcoders/api-workshop.git`
+    - Otherwise, use:`git clone https://github.com/foundersandcoders/api-workshop.git`
     - Open index.html in the browser and you will see that the API request is not working
-    - Open main.js and look for what's broken or missing in the code. If you're confused, check it line-by-line against the description of XHR in [this file](https://github.com/lucymonie/api-workshop/blob/master/03-xmlhttprequest.md)
+    - Open main.js and look for what's broken or missing in the code. If you're confused, check it line-by-line against the description of XHR in [this file](https://github.com/foundersandcoders/api-workshop/blob/master/03-xmlhttprequest.md)
 
-6. Example two: [write an XHR from scratch](https://github.com/skibinska/xhr-workshop)
-    - Click on the link and clone the repo to your local machine
-    - Follow the instructions in the readme
 
 ### Follow up and further learning
 - If you're at all hazy about how the internet works, watch [this excellent explanation]( https://www.youtube.com/watch?v=7_LPdttKXPc)


### PR DESCRIPTION
fixes #20 
fixes foundersandcoders/master-reference#519

* Fixes old links
* Removes link to XHR-workshop, since it's listed separately in the week schedule with its own time slot. Confusing to make it appear part of this workshop.